### PR TITLE
feat: Navigable macro improvements

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "66efcaf8d8ba215daab228a86e00ef18dc21d039ce50fa3060bf3836ae498922",
+  "originHash" : "d504e25fe623a1d6740a881fd0fff11e08de6419269e000bd4b18036521de16b",
   "pins" : [
     {
       "identity" : "combineext",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/goodrequest/GoodReactor.git",
       "state" : {
-        "revision" : "dcc79f4c1f0f07767f2eec05bf5c5a63477472f3",
-        "version" : "2.2.0"
+        "branch" : "feature/typeerasure",
+        "revision" : "37690c38d9f0de72543eab75ae46e3ce4cb781ce"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "12cfd2d36ff3bb2e03c47f436f5c437a7701d472899a3e7d664d47938b8d29ee",
+  "originHash" : "26034ad493b21d1ee40edbf3ab43ed701954f64a0e69f0f799ddbd50e883b649",
   "pins" : [
     {
       "identity" : "combineext",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/goodrequest/GoodReactor.git",
       "state" : {
-        "branch" : "feature/typeerasure",
-        "revision" : "e4fbf39b73ca4bf37431959dd924f06258784e46"
+        "revision" : "70da19aa3834bbe0f578e2488b594c2c5a57dd2d",
+        "version" : "2.3.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "996ec63f7dc2d5b8631231639d9d5e2328341b4597bd510bdcccb41d91c90563",
+  "originHash" : "66efcaf8d8ba215daab228a86e00ef18dc21d039ce50fa3060bf3836ae498922",
   "pins" : [
     {
       "identity" : "combineext",
@@ -67,7 +67,7 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
         "version" : "602.0.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d76c0d9c0fbddd392dac6be996a9aebc6fccbeb15724991f3bc40819d424d134",
+  "originHash" : "996ec63f7dc2d5b8631231639d9d5e2328341b4597bd510bdcccb41d91c90563",
   "pins" : [
     {
       "identity" : "combineext",
@@ -38,12 +38,21 @@
       }
     },
     {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
       "identity" : "swift-macro-testing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-macro-testing.git",
       "state" : {
-        "revision" : "20c1a8f3b624fb5d1503eadcaa84743050c350f4",
-        "version" : "0.5.2"
+        "revision" : "9ab11325daa51c7c5c10fcf16c92bac906717c7e",
+        "version" : "0.6.4"
       }
     },
     {
@@ -51,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "7b0bbbae90c41f848f90ac7b4df6c4f50068256d",
-        "version" : "1.17.5"
+        "revision" : "a8b7c5e0ed33d8ab8887d1654d9b59f2cbad529b",
+        "version" : "1.18.7"
       }
     },
     {
@@ -60,8 +69,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "b2ed9eabefe56202ee4939dd9fc46b6241c88317",
+        "version" : "1.6.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d504e25fe623a1d6740a881fd0fff11e08de6419269e000bd4b18036521de16b",
+  "originHash" : "12cfd2d36ff3bb2e03c47f436f5c437a7701d472899a3e7d664d47938b8d29ee",
   "pins" : [
     {
       "identity" : "combineext",
@@ -16,7 +16,7 @@
       "location" : "https://github.com/goodrequest/GoodReactor.git",
       "state" : {
         "branch" : "feature/typeerasure",
-        "revision" : "37690c38d9f0de72543eab75ae46e3ce4cb781ce"
+        "revision" : "e4fbf39b73ca4bf37431959dd924f06258784e46"
       }
     },
     {
@@ -24,8 +24,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "6ae9a051f76b81cc668305ceed5b0e0a7fd93d20",
-        "version" : "1.0.1"
+        "revision" : "042e1c4d9d19748c9c228f8d4ebc97bb1e339b0b",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths.git",
+      "state" : {
+        "revision" : "6989976265be3f8d2b5802c722f9ba168e227c71",
+        "version" : "1.7.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/goodrequest/GoodReactor.git", .upToNextMajor(from: "2.2.0")),
+        .package(url: "https://github.com/goodrequest/GoodReactor.git", branch: "feature/typeerasure"),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.1.3")),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0" ..< "603.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.6.4")

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
         .package(url: "https://github.com/goodrequest/GoodReactor.git", branch: "feature/typeerasure"),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.1.3")),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0" ..< "603.0.0"),
+        .package(url: "https://github.com/pointfreeco/swift-case-paths.git", .upToNextMajor(from: "1.7.2")),
         .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.6.4")
     ],
     targets: [
@@ -28,7 +29,9 @@ let package = Package(
             dependencies: [
                 .target(name: "GoodCoordinatorMacros"),
                 .product(name: "GoodReactor", package: "GoodReactor"),
-                .product(name: "Collections", package: "swift-collections")
+                .product(name: "Collections", package: "swift-collections"),
+                .product(name: "CasePaths", package: "swift-case-paths"),
+                .product(name: "CasePathsCore", package: "swift-case-paths")
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v6),

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/goodrequest/GoodReactor.git", .upToNextMajor(from: "2.2.0")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.1.3")),
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "600.0.0-latest"),
-        .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.5.2")
+        .package(url: "https://github.com/apple/swift-syntax.git", .upToNextMajor(from: "602.0.0")),
+        .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.6.4")
     ],
     targets: [
         .target(
@@ -56,3 +56,4 @@ let package = Package(
         )
     ]
 )
+

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/goodrequest/GoodReactor.git", .upToNextMajor(from: "2.2.0")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.1.3")),
-        .package(url: "https://github.com/apple/swift-syntax.git", .upToNextMajor(from: "602.0.0")),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0" ..< "603.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.6.4")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/goodrequest/GoodReactor.git", branch: "feature/typeerasure"),
+        .package(url: "https://github.com/goodrequest/GoodReactor.git", .upToNextMajor(from: "2.3.0")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.1.3")),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0" ..< "603.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-case-paths.git", .upToNextMajor(from: "1.7.2")),

--- a/Sources/GoodCoordinator/Bindings.swift
+++ b/Sources/GoodCoordinator/Bindings.swift
@@ -1,0 +1,281 @@
+//
+//  Binding.swift
+//  GoodCoordinator_v3
+//
+//  Created by Point Free Co.
+//
+
+import CasePaths
+import IssueReporting
+import SwiftUI
+
+// MARK: - Binding
+
+extension Binding {
+    /// Returns a binding to the associated value of a given case key path.
+    ///
+    /// Useful for producing bindings to values held in enum state.
+    ///
+    /// - Parameter keyPath: A case key path to a specific associated value.
+    /// - Returns: A new binding.
+    public subscript<Member>(
+        dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, Member>>
+    ) -> Binding<Member>?
+    where Value: CasePathable {
+        Binding<Member>(unwrapping: self[keyPath])
+    }
+
+    /// Returns a binding to the associated value of a given case key path.
+    ///
+    /// Useful for driving navigation off an optional enumeration of destinations.
+    ///
+    /// - Parameter keyPath: A case key path to a specific associated value.
+    /// - Returns: A new binding.
+    public subscript<Enum: CasePathable, Member>(
+        dynamicMember keyPath: KeyPath<Enum.AllCasePaths, AnyCasePath<Enum, Member>>
+    ) -> Binding<Member?>
+    where Value == Enum? {
+        self[keyPath]
+    }
+
+    /// Returns a binding to a Boolean for a given case key path to a case without an associated
+    /// value.
+    ///
+    /// Useful for driving navigation off an optional enumeration of destinations for navigation
+    /// APIs that take a Boolean binding.
+    ///
+    /// - Parameter keyPath: A case key path to a specific associated value.
+    /// - Returns: A new binding.
+    public subscript<Enum: CasePathable>(
+        dynamicMember keyPath: KeyPath<Enum.AllCasePaths, AnyCasePath<Enum, Void>>
+    ) -> Binding<Bool>
+    where Value == Enum? {
+        Binding<Bool>(self[keyPath])
+    }
+
+    /// Creates a binding by projecting the base value to an unwrapped value.
+    ///
+    /// Useful for producing non-optional bindings from optional ones.
+    ///
+    /// > Note: SwiftUI comes with an equivalent failable initializer, `Binding.init(_:)`, but using
+    /// > it can lead to crashes at runtime. [Feedback][FB8367784] has been filed, but in the meantime
+    /// > this initializer exists as a workaround.
+    ///
+    /// [FB8367784]: https://gist.github.com/stephencelis/3a232a1b718bab0ae1127ebd5fcf6f97
+    ///
+    /// - Parameter base: A value to project to an unwrapped value.
+    public init?(unwrapping base: Binding<Value?>) {
+        guard let value = base.wrappedValue else { return nil }
+        self.init(unwrapping: base, default: value)
+    }
+
+    public init(unwrapping base: Binding<Value?>, default value: Value) {
+        self = base[default: DefaultSubscript(value)]
+    }
+
+    /// Creates a binding that ignores writes to its wrapped value when equivalent to the new value.
+    ///
+    /// Useful to minimize writes to bindings passed to SwiftUI APIs. For example, [`NavigationLink`
+    /// may write `nil` twice][FB9404926] when dismissing its destination via the navigation bar's
+    /// back button. Logic attached to this dismissal will execute twice, which may not be desirable.
+    ///
+    /// [FB9404926]: https://gist.github.com/mbrandonw/70df235e42d505b3b1b9b7d0d006b049
+    ///
+    /// - Parameter isDuplicate: A closure to evaluate whether two elements are equivalent, for
+    ///   purposes of filtering writes. Return `true` from this closure to indicate that the second
+    ///   element is a duplicate of the first.
+    public func removeDuplicates(
+        by isDuplicate: @Sendable @escaping (Value, Value) -> Bool
+    ) -> Self where Value: Sendable {
+        .init(
+            get: { self.wrappedValue },
+            set: { newValue, transaction in
+                guard !isDuplicate(self.wrappedValue, newValue) else { return }
+                self.transaction(transaction).wrappedValue = newValue
+            }
+        )
+    }
+}
+
+extension Binding where Value: Equatable, Value: Sendable {
+    /// Creates a binding that ignores writes to its wrapped value when equivalent to the new value.
+    ///
+    /// Useful to minimize writes to bindings passed to SwiftUI APIs. For example, [`NavigationLink`
+    /// may write `nil` twice][FB9404926] when dismissing its destination via the navigation bar's
+    /// back button. Logic attached to this dismissal will execute twice, which may not be desirable.
+    ///
+    /// [FB9404926]: https://gist.github.com/mbrandonw/70df235e42d505b3b1b9b7d0d006b049
+    public func removeDuplicates() -> Self {
+        self.removeDuplicates(by: { $0 == $1 })
+    }
+}
+
+extension Binding where Value: Sendable {
+    public func _printChanges(
+        _ prefix: String = "",
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) -> Self {
+        Self(
+            get: { self.wrappedValue },
+            set: { newValue, transaction in
+                var oldDescription = ""
+                debugPrint(self.wrappedValue, terminator: "", to: &oldDescription)
+                var newDescription = ""
+                debugPrint(newValue, terminator: "", to: &newDescription)
+                print(
+                    "\(prefix.isEmpty ? "\(Self.self)@\(fileID):\(line)" : prefix):",
+                    oldDescription,
+                    "→",
+                    newDescription
+                )
+                self.transaction(transaction).wrappedValue = newValue
+            }
+        )
+    }
+}
+
+// MARK: - Optional
+
+extension Optional {
+    fileprivate subscript(default defaultSubscript: DefaultSubscript<Wrapped>) -> Wrapped {
+        get {
+            defaultSubscript.value = self ?? defaultSubscript.value
+            return defaultSubscript.value
+        }
+        set {
+            defaultSubscript.value = newValue
+            if self != nil { self = newValue }
+        }
+    }
+}
+
+private final class DefaultSubscript<Value>: Hashable {
+    var value: Value
+    init(_ value: Value) {
+        self.value = value
+    }
+    static func == (lhs: DefaultSubscript, rhs: DefaultSubscript) -> Bool {
+        lhs === rhs
+    }
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+}
+
+extension CasePathable {
+    fileprivate subscript<Member>(
+        keyPath: KeyPath<Self.AllCasePaths, AnyCasePath<Self, Member>>
+    ) -> Member? {
+        get {
+            Self.allCasePaths[keyPath: keyPath].extract(from: self)
+        }
+        set {
+            guard let newValue else { return }
+            self = Self.allCasePaths[keyPath: keyPath].embed(newValue)
+        }
+    }
+}
+
+extension Optional where Wrapped: CasePathable {
+    fileprivate subscript<Member>(
+        keyPath: KeyPath<Wrapped.AllCasePaths, AnyCasePath<Wrapped, Member>>
+    ) -> Member? {
+        get {
+            self.flatMap(Wrapped.allCasePaths[keyPath: keyPath].extract(from:))
+        }
+        set {
+            let casePath = Wrapped.allCasePaths[keyPath: keyPath]
+            guard self.flatMap(casePath.extract(from:)) != nil
+            else { return }
+            self = newValue.map(casePath.embed)
+        }
+    }
+}
+
+extension Binding where Value: Sendable {
+    func didSet(_ perform: @escaping @Sendable (Value) -> Void) -> Self {
+        .init(
+            get: { self.wrappedValue },
+            set: { newValue, transaction in
+                self.transaction(transaction).wrappedValue = newValue
+                perform(newValue)
+            }
+        )
+    }
+}
+
+// MARK: - Boolean binding
+
+extension Binding {
+    /// Creates a binding by projecting the base optional value to a Boolean value.
+    ///
+    /// Writing `false` to the binding will `nil` out the base value. Writing `true` produces a
+    /// runtime warning.
+    ///
+    /// - Parameter base: A value to project to a Boolean value.
+    public init<V>(
+        _ base: Binding<V?>,
+        fileID: StaticString = #fileID,
+        filePath: StaticString = #filePath,
+        line: UInt = #line,
+        column: UInt = #column
+    ) where Value == Bool {
+        self =
+        base[
+            fileID: HashableStaticString(rawValue: fileID),
+            filePath: HashableStaticString(rawValue: filePath),
+            line: line,
+            column: column
+        ]
+    }
+}
+
+extension Optional {
+    fileprivate subscript(
+        fileID fileID: HashableStaticString,
+        filePath filePath: HashableStaticString,
+        line line: UInt,
+        column column: UInt
+    ) -> Bool {
+        get { self != nil }
+        set {
+            if newValue {
+                reportIssue(
+                    """
+                    Boolean presentation binding attempted to write 'true' to a generic 'Binding<Item?>' \
+                    (i.e., 'Binding<\(Wrapped.self)?>').
+                    
+                    This is not a valid thing to do, as there is no way to convert 'true' to a new \
+                    instance of '\(Wrapped.self)'.
+                    """,
+                    fileID: fileID.rawValue,
+                    filePath: filePath.rawValue,
+                    line: line,
+                    column: column
+                )
+            } else {
+                self = nil
+            }
+        }
+    }
+}
+
+// MARK: - Hashable static string
+
+package struct HashableStaticString: Hashable {
+    package var rawValue: StaticString
+
+    package init(rawValue: StaticString) {
+        self.rawValue = rawValue
+    }
+
+    package static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue.description == rhs.rawValue.description
+    }
+
+    package func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue.description)
+    }
+}
+

--- a/Sources/GoodCoordinator/CoordinatorConfiguration.swift
+++ b/Sources/GoodCoordinator/CoordinatorConfiguration.swift
@@ -5,11 +5,9 @@
 //  Created by Matus Klasovity on 11/06/2025.
 //
 
-
 import Foundation
 
-@MainActor
-public struct CoordinatorConfiguration: Sendable {
+@MainActor public struct CoordinatorConfiguration: Sendable {
 
     private init() {}
 

--- a/Sources/GoodCoordinator/Exports.swift
+++ b/Sources/GoodCoordinator/Exports.swift
@@ -1,0 +1,12 @@
+//
+//  Exports.swift
+//  GoodCoordinator_v3
+//
+//  Created by Filip Šašala on 26/09/2025.
+//
+
+@_exported import CasePaths
+@_exported import CasePathsCore
+
+public typealias DestinationCaseNavigable = CasePathable & CasePathIterable & Hashable & Sendable
+public typealias AnyDestination = (any DestinationCaseNavigable)

--- a/Sources/GoodCoordinator/Macros.swift
+++ b/Sources/GoodCoordinator/Macros.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 @attached(extension, conformances: DestinationCaseNavigable)
+@attached(member, names: named(AllCasePaths), named(allCasePaths), named(_$Element))
 @attached(peer, names: arbitrary)
 public macro Navigable() = #externalMacro(module: "GoodCoordinatorMacros", type: "Navigable")
 

--- a/Sources/GoodCoordinator/Models/NavigationMap.swift
+++ b/Sources/GoodCoordinator/Models/NavigationMap.swift
@@ -84,7 +84,7 @@ import GoodReactor
 
     // MARK: - Get
 
-    nonmutating func get<R: Reactor>(for reactor: R) -> TreeNode<NavigationStep>? {
+    nonmutating func get<R: Reactor>(for reactor: R) -> TreeNode<NavigationStep>? {
 //        if let node = nodeMap[reactor], node.value.isActive {
 //            return node
 //        } else {

--- a/Sources/GoodCoordinator/Models/NavigationStep.swift
+++ b/Sources/GoodCoordinator/Models/NavigationStep.swift
@@ -5,8 +5,6 @@
 //  Created by Filip Šašala on 26/09/2024.
 //
 
-import GoodReactor
-
 struct NavigationStep {
 
     var reactor: AnyReactor?

--- a/Sources/GoodCoordinator/Typealiases.swift
+++ b/Sources/GoodCoordinator/Typealiases.swift
@@ -1,9 +1,0 @@
-//
-//  Typealiases.swift
-//  GoodCoordinator_v3
-//
-//  Created by Filip Šašala on 19/09/2024.
-//
-
-public typealias DestinationCaseNavigable = Hashable & Sendable
-public typealias AnyDestination = (any DestinationCaseNavigable)

--- a/Sources/GoodCoordinatorMacros/Macros/CasePathableMacro.swift
+++ b/Sources/GoodCoordinatorMacros/Macros/CasePathableMacro.swift
@@ -1,0 +1,482 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct CasePathableMacro {
+  static let moduleName = "CasePaths"
+  static let casePathTypeName = "AnyCasePath"
+}
+
+extension CasePathableMacro: MemberMacro {
+  public static func expansion<
+    Declaration: DeclGroupSyntax, Context: MacroExpansionContext
+  >(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: Declaration,
+    in context: Context
+  ) throws -> [DeclSyntax] {
+    guard let enumDecl = declaration.as(EnumDeclSyntax.self)
+    else {
+      throw DiagnosticsError(
+        diagnostics: [
+          CasePathableMacroDiagnostic
+            .notAnEnum(declaration)
+            .diagnose(at: declaration.keyword)
+        ]
+      )
+    }
+    let enumName = enumDecl.name.trimmed
+
+    let enumCaseDecls = enumDecl.memberBlock.members
+      .flatMap { $0.decl.as(EnumCaseDeclSyntax.self)?.elements ?? [] }
+
+    var seenCaseNames: Set<String> = []
+    for enumCaseDecl in enumCaseDecls {
+      let name = enumCaseDecl.name.text
+      if seenCaseNames.contains(name) {
+        throw DiagnosticsError(
+          diagnostics: [
+            CasePathableMacroDiagnostic.overloadedCaseName(name).diagnose(
+              at: Syntax(enumCaseDecl.name))
+          ]
+        )
+      }
+      seenCaseNames.insert(name)
+    }
+
+    let selfRewriter = SelfRewriter(selfEquivalent: enumName)
+    let memberBlock = selfRewriter.rewrite(enumDecl.memberBlock).cast(MemberBlockSyntax.self)
+    let rootSubscriptCases = generateCases(from: memberBlock.members, enumName: enumName) {
+      "if root.is(\\.\(raw: $0.name.text)) { return \\.\(raw: $0.name.text) }"
+    }
+    let elementRewriter = ElementRewriter()
+    let casePaths = generateDeclSyntax(from: memberBlock.members, enumName: enumName).map {
+      elementRewriter.rewrite($0)
+    }
+    let allCases = generateCases(from: memberBlock.members, enumName: enumName) {
+      "allCasePaths.append(\\.\(raw: $0.name.text))"
+    }
+
+    let subscriptReturn = allCases.isEmpty ? #"\.never"# : #"return \.never"#
+
+    var decls: [DeclSyntax] = [
+      """
+      public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
+      public subscript(root: \(enumName)) -> CasePaths.PartialCaseKeyPath<\(enumName)> {
+      \(raw: rootSubscriptCases.map { "\($0.description)\n" }.joined())\(raw: subscriptReturn)
+      }
+      \(raw: casePaths.map(\.description).joined(separator: "\n"))
+      public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<\(enumName)>]> {
+      \(raw: allCases.isEmpty ? "let" : "var") allCasePaths: \
+      [CasePaths.PartialCaseKeyPath<\(enumName)>] = []\
+      \(raw: allCases.map { "\n\($0.description)" }.joined())
+      return allCasePaths.makeIterator()
+      }
+      }
+      public static var allCasePaths: AllCasePaths { AllCasePaths() }
+      """
+    ]
+
+    if elementRewriter.didRewriteElement {
+      decls.append("public typealias _$Element = Element")
+    }
+
+    return decls
+  }
+
+  static func generateCases(
+    from elements: MemberBlockItemListSyntax,
+    enumName: TokenSyntax,
+    body: (EnumCaseElementSyntax) -> DeclSyntax
+  ) -> [DeclSyntax] {
+    elements.flatMap {
+      if let decl = $0.decl.as(EnumCaseDeclSyntax.self) {
+        return decl.elements.map(body)
+      }
+      if let ifConfigDecl = $0.decl.as(IfConfigDeclSyntax.self) {
+        let ifClauses = ifConfigDecl.clauses.flatMap { decl -> [DeclSyntax] in
+          guard let elements = decl.elements?.as(MemberBlockItemListSyntax.self) else {
+            return []
+          }
+          let title = "\(decl.poundKeyword.text) \(decl.condition?.description ?? "")"
+          return ["\(raw: title)"]
+            + generateCases(from: elements, enumName: enumName, body: body)
+        }
+        return ifClauses + ["#endif"]
+      }
+      return []
+    }
+  }
+
+  static func generateDeclSyntax(
+    from elements: MemberBlockItemListSyntax,
+    enumName: TokenSyntax
+  ) -> [DeclSyntax] {
+    elements.flatMap {
+      if let decl = $0.decl.as(EnumCaseDeclSyntax.self) {
+        return generateDeclSyntax(from: decl, enumName: enumName)
+      }
+      if let ifConfigDecl = $0.decl.as(IfConfigDeclSyntax.self) {
+        let ifClauses = ifConfigDecl.clauses.flatMap { decl -> [DeclSyntax] in
+          guard let elements = decl.elements?.as(MemberBlockItemListSyntax.self) else {
+            return []
+          }
+          let title = "\(decl.poundKeyword.text) \(decl.condition?.description ?? "")"
+          return ["\(raw: title)"]
+            + generateDeclSyntax(from: elements, enumName: enumName)
+        }
+        return ifClauses + ["#endif"]
+      }
+      return []
+    }
+  }
+
+  static func generateDeclSyntax(
+    from decl: EnumCaseDeclSyntax,
+    enumName: TokenSyntax
+  ) -> [DeclSyntax] {
+    decl.elements.map {
+      let caseName = $0.name.trimmed
+      let associatedValueName = $0.trimmedTypeDescription
+      let hasPayload = $0.parameterClause.map { !$0.parameters.isEmpty } ?? false
+      let embed: DeclSyntax = hasPayload ? "\(enumName).\(caseName)" : "{ \(enumName).\(caseName) }"
+      let bindingNames: String
+      let returnName: String
+      if hasPayload, let associatedValue = $0.parameterClause {
+        let parameterNames = (0..<associatedValue.parameters.count)
+          .map { "v\($0)" }
+          .joined(separator: ", ")
+        bindingNames = "(\(parameterNames))"
+        returnName = associatedValue.parameters.count == 1 ? parameterNames : bindingNames
+      } else {
+        bindingNames = ""
+        returnName = "()"
+      }
+      let leadingTriviaLines = decl.leadingTrivia.description
+        .drop(while: \.isNewline)
+        .split(separator: "\n", omittingEmptySubsequences: false)
+      let indent =
+        leadingTriviaLines
+        .compactMap { $0.isEmpty ? nil : $0.prefix(while: \.isWhitespace).count }
+        .min(by: { (lhs: Int, rhs: Int) -> Bool in lhs < rhs })
+        ?? 0
+      let leadingTrivia =
+        leadingTriviaLines
+        .map { String($0.dropFirst(indent)) }
+        .joined(separator: "\n")
+        .trimmingSuffix(while: { $0.isWhitespace && !$0.isNewline })
+      return """
+        \(raw: leadingTrivia)public var \(caseName): \
+        \(raw: casePathTypeName.qualified)<\(enumName), \(raw: associatedValueName)> {
+        ._$embed(\(embed)) {
+        guard case\(raw: hasPayload ? " let" : "").\(caseName)\(raw: bindingNames) = $0 else { \
+        return nil \
+        }
+        return \(raw: returnName)
+        }
+        }
+        """
+    }
+  }
+}
+
+enum CasePathableMacroDiagnostic {
+  case notAnEnum(DeclGroupSyntax)
+  case overloadedCaseName(String)
+}
+
+extension CasePathableMacroDiagnostic: DiagnosticMessage {
+  var message: String {
+    switch self {
+    case let .notAnEnum(decl):
+      return """
+        '@CasePathable' cannot be applied to\
+        \(decl.keywordDescription.map { " \($0)" } ?? "") type\
+        \(decl.nameDescription.map { " '\($0)'" } ?? "")
+        """
+    case let .overloadedCaseName(name):
+      return """
+        '@CasePathable' cannot be applied to overloaded case name '\(name)'
+        """
+    }
+  }
+
+  var diagnosticID: MessageID {
+    switch self {
+    case .notAnEnum:
+      return MessageID(domain: "MetaEnumDiagnostic", id: "notAnEnum")
+    case .overloadedCaseName:
+      return MessageID(domain: "MetaEnumDiagnostic", id: "overloadedCaseName")
+    }
+  }
+
+  var severity: DiagnosticSeverity {
+    switch self {
+    case .notAnEnum:
+      return .error
+    case .overloadedCaseName:
+      return .error
+    }
+  }
+
+  func diagnose(at node: Syntax) -> Diagnostic {
+    Diagnostic(node: node, message: self)
+  }
+}
+
+extension AttributeListSyntax {
+  var availability: AttributeListSyntax? {
+    var elements = [AttributeListSyntax.Element]()
+    for element in self {
+      if let availability = element.availability {
+        elements.append(availability)
+      }
+    }
+    if elements.isEmpty {
+      return nil
+    }
+    return AttributeListSyntax(elements)
+  }
+}
+
+extension AttributeListSyntax.Element {
+  var availability: AttributeListSyntax.Element? {
+    switch self {
+    case .attribute(let attribute):
+      if let availability = attribute.availability {
+        return .attribute(availability)
+      }
+    case .ifConfigDecl(let ifConfig):
+      if let availability = ifConfig.availability {
+        return .ifConfigDecl(availability)
+      }
+    @unknown default: return nil
+    }
+    return nil
+  }
+}
+
+extension AttributeSyntax {
+  var availability: AttributeSyntax? {
+    if attributeName.identifier == "available" {
+      return self
+    } else {
+      return nil
+    }
+  }
+}
+
+extension IfConfigClauseSyntax {
+  var availability: IfConfigClauseSyntax? {
+    if let availability = elements?.availability {
+      return with(\.elements, availability)
+    } else {
+      return nil
+    }
+  }
+
+  var clonedAsIf: IfConfigClauseSyntax {
+    detached.with(\.poundKeyword, .poundIfToken())
+  }
+}
+
+extension IfConfigClauseSyntax.Elements {
+  var availability: IfConfigClauseSyntax.Elements? {
+    switch self {
+    case .attributes(let attributes):
+      if let availability = attributes.availability {
+        return .attributes(availability)
+      } else {
+        return nil
+      }
+    default:
+      return nil
+    }
+  }
+}
+
+extension IfConfigDeclSyntax {
+  var availability: IfConfigDeclSyntax? {
+    var elements = [IfConfigClauseListSyntax.Element]()
+    for clause in clauses {
+      if let availability = clause.availability {
+        if elements.isEmpty {
+          elements.append(availability.clonedAsIf)
+        } else {
+          elements.append(availability)
+        }
+      }
+    }
+    if elements.isEmpty {
+      return nil
+    } else {
+      return with(\.clauses, IfConfigClauseListSyntax(elements))
+    }
+  }
+}
+
+extension DeclGroupSyntax {
+  var keyword: Syntax {
+    switch self {
+    case let syntax as ActorDeclSyntax:
+      return Syntax(syntax.actorKeyword)
+    case let syntax as ClassDeclSyntax:
+      return Syntax(syntax.classKeyword)
+    case let syntax as ExtensionDeclSyntax:
+      return Syntax(syntax.extensionKeyword)
+    case let syntax as ProtocolDeclSyntax:
+      return Syntax(syntax.protocolKeyword)
+    case let syntax as StructDeclSyntax:
+      return Syntax(syntax.structKeyword)
+    case let syntax as EnumDeclSyntax:
+      return Syntax(syntax.enumKeyword)
+    default:
+      return Syntax(self)
+    }
+  }
+
+  var keywordDescription: String? {
+    switch self {
+    case let syntax as ActorDeclSyntax:
+      return syntax.actorKeyword.trimmedDescription
+    case let syntax as ClassDeclSyntax:
+      return syntax.classKeyword.trimmedDescription
+    case let syntax as ExtensionDeclSyntax:
+      return syntax.extensionKeyword.trimmedDescription
+    case let syntax as ProtocolDeclSyntax:
+      return syntax.protocolKeyword.trimmedDescription
+    case let syntax as StructDeclSyntax:
+      return syntax.structKeyword.trimmedDescription
+    case let syntax as EnumDeclSyntax:
+      return syntax.enumKeyword.trimmedDescription
+    default:
+      return nil
+    }
+  }
+
+  var nameDescription: String? {
+    switch self {
+    case let syntax as ActorDeclSyntax:
+      return syntax.name.trimmedDescription
+    case let syntax as ClassDeclSyntax:
+      return syntax.name.trimmedDescription
+    case let syntax as ExtensionDeclSyntax:
+      return syntax.extendedType.trimmedDescription
+    case let syntax as ProtocolDeclSyntax:
+      return syntax.name.trimmedDescription
+    case let syntax as StructDeclSyntax:
+      return syntax.name.trimmedDescription
+    case let syntax as EnumDeclSyntax:
+      return syntax.name.trimmedDescription
+    default:
+      return nil
+    }
+  }
+}
+
+extension EnumCaseElementListSyntax.Element {
+  var trimmedTypeDescription: String {
+    if var associatedValue = self.parameterClause, !associatedValue.parameters.isEmpty {
+      if associatedValue.parameters.count == 1,
+        let type = associatedValue.parameters.first?.type.trimmed
+      {
+        return type.is(SomeOrAnyTypeSyntax.self)
+          ? "(\(type))"
+          : "\(type)"
+      } else {
+        for index in associatedValue.parameters.indices {
+          associatedValue.parameters[index].type.trailingTrivia = ""
+          associatedValue.parameters[index].defaultValue = nil
+          if associatedValue.parameters[index].firstName?.tokenKind == .wildcard {
+            associatedValue.parameters[index].colon = nil
+            associatedValue.parameters[index].firstName = nil
+            associatedValue.parameters[index].secondName = nil
+          }
+        }
+
+        // Remove trailing comma from the last parameter for tuple type generation
+        if let lastIndex = associatedValue.parameters.indices.last {
+          associatedValue.parameters[lastIndex] = associatedValue.parameters[lastIndex]
+            .with(\.trailingComma, nil)
+        }
+
+        return "(\(associatedValue.parameters.trimmed))"
+      }
+    } else {
+      return "Void"
+    }
+  }
+}
+
+extension SyntaxStringInterpolation {
+  mutating func appendInterpolation<Node: SyntaxProtocol>(_ node: Node?) {
+    if let node {
+      self.appendInterpolation(node)
+    }
+  }
+}
+
+extension TypeSyntax {
+  var identifier: String? {
+    for token in tokens(viewMode: .all) {
+      switch token.tokenKind {
+      case .identifier(let identifier):
+        return identifier
+      default:
+        break
+      }
+    }
+    return nil
+  }
+}
+
+final class SelfRewriter: SyntaxRewriter {
+  let selfEquivalent: TokenSyntax
+
+  init(selfEquivalent: TokenSyntax) {
+    self.selfEquivalent = selfEquivalent
+  }
+
+  override func visit(_ node: IdentifierTypeSyntax) -> TypeSyntax {
+    guard node.name.text == "Self"
+    else { return super.visit(node) }
+    return super.visit(node.with(\.name, self.selfEquivalent))
+  }
+}
+
+final class ElementRewriter: SyntaxRewriter {
+  var didRewriteElement = false
+
+  override func visit(_ node: IdentifierTypeSyntax) -> TypeSyntax {
+    guard node.name.text == "Element"
+    else { return super.visit(node) }
+    didRewriteElement = true
+    return super.visit(node.with(\.name, "_$Element"))
+  }
+}
+
+extension [String] {
+  package var qualified: [String] {
+    map(\.qualified)
+  }
+}
+
+extension String {
+  package var qualified: String {
+    "\(CasePathableMacro.moduleName).\(self)"
+  }
+}
+
+extension StringProtocol {
+  @inline(__always)
+  func trimmingSuffix(while condition: (Element) throws -> Bool) rethrows -> Self.SubSequence {
+    var view = self[...]
+
+    while let character = view.last, try condition(character) {
+      view = view.dropLast()
+    }
+
+    return view
+  }
+}

--- a/Sources/GoodCoordinatorMacros/Macros/Navigable.swift
+++ b/Sources/GoodCoordinatorMacros/Macros/Navigable.swift
@@ -65,7 +65,8 @@ public struct Navigable: ExtensionMacro, PeerMacro {
 
         let enclosingClassName = enclosingClassDecl.name.text
 
-        let classHeader = "@Observable @MainActor final class _DestinationsActive {"
+        let classConformances = "__ReactorDirectWritable"
+        let classHeader = "@Observable @MainActor final class _DestinationsActive: \(classConformances) {"
         let classFields = "fileprivate weak var reactor: \(enclosingClassName)?"
         let classFooter = "}"
 
@@ -97,9 +98,9 @@ public struct Navigable: ExtensionMacro, PeerMacro {
         let observationTracked = DeclSyntax("""
         {
             get {
-                defer { modelActive = true }
+                defer { _modelActive = true }
                 access(keyPath: \\.destination)
-                if !modelActive {
+                if !_modelActive {
                     return #router.getOrInsert(for: self)
                 } else {
                     return #router.get(for: self)
@@ -130,8 +131,8 @@ public struct Navigable: ExtensionMacro, PeerMacro {
         // var destinations
         let destinationsDecl = DeclSyntax("var destinations = _DestinationsActive()")
 
-        // var modelActive
-        let modelActiveVarDecl = DeclSyntax("var modelActive: Bool = false")
+        // var _modelActive
+        let modelActiveVarDecl = DeclSyntax("var _modelActive: Bool = false")
 
         return [
             destinationsActiveDecl,


### PR DESCRIPTION
Navigable macro improvements. Navigable macro now doesn't generate new stored properties in Reactor, making autocomplete work better, with less false suggestions and ghost compilation errors.

Migration guide:
- Replace `destinations` with `destination` (previous name is still available, but deprecated)
- Remove `if case let` checks on destinations with associated values and use closure parameters instead
- Use `item` variants of navigation with parameters

<img width="723" height="146" alt="image" src="https://github.com/user-attachments/assets/c4d56fbf-0c3b-44f0-b88d-7b9293d8471c" />

Also:
- Fix typos
- Fix tests
- Update Swift toolchain to Swift 6.2